### PR TITLE
Update SDK version to match latest change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "testapp"
 path = "src/bin/main.rs" #
 
 [dependencies]
-sovereign-sdk =  { git = "https://github.com/Sovereign-Labs/sovereign.git", rev = "bfdb58159ff9215a84aa60b9a4d3ce1f32136597" }
+sovereign-sdk =  { git = "https://github.com/Sovereign-Labs/sovereign.git", rev = "80010ef48750dddc590eac887be1f892ee51feed" }
 tendermint = "0.27"
 
 prost = "0.11"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2023-04-17"


### PR DESCRIPTION
DaTrait has been changed, but dependency point to the older version of SDK.

Also:

* Specified rust toolchain, so `cargo run`, `cargo test`, etc will work without explicitly need for `+nightly`
* Reordered methods in `SlotData` trait implementation to match order of the trait